### PR TITLE
Feat: Add Localization of Simplified Chinese and Japanese

### DIFF
--- a/HangulTop.xcodeproj/project.pbxproj
+++ b/HangulTop.xcodeproj/project.pbxproj
@@ -98,6 +98,11 @@
 		4D31D55C288D9DBC005E2F53 /* QuizViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewController.swift; sourceTree = "<group>"; };
 		4D4927FA2897B01A00FD0175 /* consonant.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = consonant.json; sourceTree = "<group>"; };
 		4D4928032898262E00FD0175 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		4D77D83A28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Main.strings; sourceTree = "<group>"; };
+		4D77D83B28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Consonant.strings; sourceTree = "<group>"; };
+		4D77D83C28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Quiz.strings; sourceTree = "<group>"; };
+		4D77D83D28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/HangulView.strings; sourceTree = "<group>"; };
+		4D77D83E28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4D89B9CE28891CEA00BD37F7 /* ConsonantEndViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantEndViewController.swift; sourceTree = "<group>"; };
 		4D89B9D028891E9B00BD37F7 /* BatchimEndViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchimEndViewController.swift; sourceTree = "<group>"; };
 		6761C8A9288550F4001A0D2C /* BatchimModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchimModel.swift; sourceTree = "<group>"; };
@@ -328,6 +333,7 @@
 				ms,
 				fr,
 				"zh-Hant",
+				ja,
 			);
 			mainGroup = D5CC94FC287E9591005E8BF5;
 			packageReferences = (
@@ -422,6 +428,7 @@
 				A0177A5328CA2ABC00E5B78E /* ms */,
 				D53F61A428CA40F80017D756 /* fr */,
 				D53F61A928CA41500017D756 /* zh-Hant */,
+				4D77D83E28CDF0780083F9A9 /* ja */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -470,6 +477,7 @@
 				A0177A5028CA2ABC00E5B78E /* ms */,
 				D53F61A128CA40F70017D756 /* fr */,
 				D53F61A628CA414F0017D756 /* zh-Hant */,
+				4D77D83B28CDF0780083F9A9 /* ja */,
 			);
 			name = Consonant.storyboard;
 			sourceTree = "<group>";
@@ -502,6 +510,7 @@
 				A0177A5128CA2ABC00E5B78E /* ms */,
 				D53F61A228CA40F70017D756 /* fr */,
 				D53F61A728CA41500017D756 /* zh-Hant */,
+				4D77D83C28CDF0780083F9A9 /* ja */,
 			);
 			name = Quiz.storyboard;
 			sourceTree = "<group>";
@@ -518,6 +527,7 @@
 				A0177A5228CA2ABC00E5B78E /* ms */,
 				D53F61A328CA40F80017D756 /* fr */,
 				D53F61A828CA41500017D756 /* zh-Hant */,
+				4D77D83D28CDF0780083F9A9 /* ja */,
 			);
 			name = HangulView.storyboard;
 			sourceTree = "<group>";
@@ -534,6 +544,7 @@
 				A0177A4F28CA2ABC00E5B78E /* ms */,
 				D53F61A028CA40F70017D756 /* fr */,
 				D53F61A528CA414F0017D756 /* zh-Hant */,
+				4D77D83A28CDF0780083F9A9 /* ja */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -675,7 +686,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HangulTop/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HangulKing;
@@ -708,7 +719,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HangulTop/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HangulKing;

--- a/HangulTop.xcodeproj/project.pbxproj
+++ b/HangulTop.xcodeproj/project.pbxproj
@@ -103,6 +103,11 @@
 		4D77D83C28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Quiz.strings; sourceTree = "<group>"; };
 		4D77D83D28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/HangulView.strings; sourceTree = "<group>"; };
 		4D77D83E28CDF0780083F9A9 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4D77D83F28CE27920083F9A9 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
+		4D77D84028CE27920083F9A9 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Consonant.strings"; sourceTree = "<group>"; };
+		4D77D84128CE27920083F9A9 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Quiz.strings"; sourceTree = "<group>"; };
+		4D77D84228CE27920083F9A9 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/HangulView.strings"; sourceTree = "<group>"; };
+		4D77D84328CE27920083F9A9 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		4D89B9CE28891CEA00BD37F7 /* ConsonantEndViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantEndViewController.swift; sourceTree = "<group>"; };
 		4D89B9D028891E9B00BD37F7 /* BatchimEndViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchimEndViewController.swift; sourceTree = "<group>"; };
 		6761C8A9288550F4001A0D2C /* BatchimModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchimModel.swift; sourceTree = "<group>"; };
@@ -334,6 +339,7 @@
 				fr,
 				"zh-Hant",
 				ja,
+				"zh-Hans",
 			);
 			mainGroup = D5CC94FC287E9591005E8BF5;
 			packageReferences = (
@@ -429,6 +435,7 @@
 				D53F61A428CA40F80017D756 /* fr */,
 				D53F61A928CA41500017D756 /* zh-Hant */,
 				4D77D83E28CDF0780083F9A9 /* ja */,
+				4D77D84328CE27920083F9A9 /* zh-Hans */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -478,6 +485,7 @@
 				D53F61A128CA40F70017D756 /* fr */,
 				D53F61A628CA414F0017D756 /* zh-Hant */,
 				4D77D83B28CDF0780083F9A9 /* ja */,
+				4D77D84028CE27920083F9A9 /* zh-Hans */,
 			);
 			name = Consonant.storyboard;
 			sourceTree = "<group>";
@@ -511,6 +519,7 @@
 				D53F61A228CA40F70017D756 /* fr */,
 				D53F61A728CA41500017D756 /* zh-Hant */,
 				4D77D83C28CDF0780083F9A9 /* ja */,
+				4D77D84128CE27920083F9A9 /* zh-Hans */,
 			);
 			name = Quiz.storyboard;
 			sourceTree = "<group>";
@@ -528,6 +537,7 @@
 				D53F61A328CA40F80017D756 /* fr */,
 				D53F61A828CA41500017D756 /* zh-Hant */,
 				4D77D83D28CDF0780083F9A9 /* ja */,
+				4D77D84228CE27920083F9A9 /* zh-Hans */,
 			);
 			name = HangulView.storyboard;
 			sourceTree = "<group>";
@@ -545,6 +555,7 @@
 				D53F61A028CA40F70017D756 /* fr */,
 				D53F61A528CA414F0017D756 /* zh-Hant */,
 				4D77D83A28CDF0780083F9A9 /* ja */,
+				4D77D83F28CE27920083F9A9 /* zh-Hans */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";

--- a/HangulTop/Localization/ja.lproj/Localizable.strings
+++ b/HangulTop/Localization/ja.lproj/Localizable.strings
@@ -1,0 +1,52 @@
+/* 
+  Localizable.strings
+  HangulTop
+
+  Created by Seulki Lee on 2022/09/07.
+  
+*/
+
+"hangulKing" = "ハングルキング";
+"learn" = "学習";
+"vowel" = "母音";
+"consonant" = "子音";
+"batchim" = "バッチム";
+"practice" = "練習";
+"quiz" = "クイズ";
+"hangul" = "ハングル";
+"vowelPrinciple" = "母音は、\n•(空)、ㅡ(地)、ㅣ(人間) に基づいており、「天地人」とも呼ばれ、宇宙の基礎を表しています。\n\n• 最近では、このように単独で使用されるわけではありません。単体では音が出ません。";
+"consonantPrinciple" = "子音は、人間の発音器官の形状をモデルにしています。\n\n5 つの基本的な子音「ㄱ、ㄷ、ㅂ、ㅅ、ㅈ」を作成し、これらの文字にストロークを追加することで、より強い音の子音を作成しました。";
+"batchimPrinciple" = "パッチムは子音母音の組み合わせの後に来る追加の子音です。\n\nほとんどの子音はバッチィムですが、常に7つの子音の1つとして発音されます。「ㄱ、ㄴ、ㄷ、ㄹ、ㅁ、ㅇ」です。";
+"vowelExplanation1" = "母音は単独では使用されません。ここで「ㅇ」は、各母音の前の空白を表します。";
+"doubleConsonantExplanation" = "二重子音は、基本子音である「ㄱ、ㄷ、ㅂ、ㅅ、ㅈ」を2回書く形です。";
+"batchimExplanation" = "頭の子音として使わないダブルバッチムもありますが、ほとんど使わないので安心してください！";
+"vowelExplanation2" = "「ㅡ」 は常に子音の下に移動しますが、\n「ㅣ」 は右に移動します。";
+"vowelExplanation3" = "基本母音に「・」が1つ付きます。";
+"vowelExplanation4" = "基本母音に2「・」が追加されました。";
+"vowelExplanation5" = "「・」基礎母音にと「ㅣ」つけました。";
+"vowelExplanation6" = "二つの母音が一つに！\n順番に素早く読んでください。";
+"vowelDone" = "ハングルの母音を\n覚えたんですね！";
+"consonantDone" = "ハングルの子音を\n覚えたんですね！";
+"batchimDone" = "ハングルのバッチイムを\n覚えました!";
+"learnConsonant" = "子音学習";
+"learnBatchim" = "パッチム学習";
+"goToQuiz" = "クイズに行く";
+"correct" = "正しい！";
+"tryAgain" = "再試行...";
+"youHaveFinished" = "ここまでで";
+"questionsSoFar" = "つの質問が完了しました。";
+"lv1" = "lv 1。母音";
+"lv3" = "lv 3。パッチム";
+"lv2" = "lv 2。子音";
+"check" = "確認";
+"velarSound" = "口蓋音";
+"lingualSound" = "舌の音";
+"labialSound" = "唇の音";
+"dentalSound" = "歯の音";
+"gutturalSound" = "喉の音";
+"velarSoundExplanation" = "軟口蓋に触れる舌の形";
+"lingualSoundExplanation" = "上の歯ぐきに触れる舌先の形";
+"labialSoundExplanation" = "唇の形";
+"dentalSoundExplanation" = "歯の形";
+"gutturalSoundExplanation" = "喉の形";
+"combine" = "独自のハングルを組み合わせて、それがどのように聞こえるかを聞いてください。";

--- a/HangulTop/Localization/zh-Hans.lproj/Localizable.strings
+++ b/HangulTop/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,52 @@
+/* 
+  Localizable.strings
+  HangulTop
+
+  Created by Seulki Lee on 2022/09/07.
+  
+*/
+
+"hangulKing" = "韩文王";
+"learn" = "学";
+"vowel" = "元音";
+"consonant" = "辅音";
+"batchim" = "Batchim";
+"practice" = "练习";
+"quiz" = "测验";
+"hangul" = "韩文";
+"vowelPrinciple" = "元音仿照：\n•（天空）、ㅡ（地球）、ㅣ（人类），也称为“天地人”，代表宇宙的基础。\n\n•现在不单独使用了，因为它本身没有声音。";
+"consonantPrinciple" = "辅音模仿人类发音器官的形状。\n\n创造了五个基本辅音 ‘ㄱ、ㄷ、ㅂ、ㅅ、ㅈ’，并通过在这些字母上添加笔画来创建发音更强烈的辅音。";
+"batchimPrinciple" = "Batchim 是一个附加的辅音，出现在辅音元音组合之后。\n\n大多数辅音可以是batchim，但它们总是发音为7个辅音之一，'ㄱ、ㄴ、ㄷ、ㄹ、ㅁ、ㅇ'。";
+"vowelExplanation1" = "元音不单独使用。这里的'ㅇ'表示每个元音前面的语音空白。";
+"doubleConsonantExplanation" = "双辅音是把基本辅音‘ㄱ、ㄷ、ㅂ、ㅅ、ㅈ’写两次的一种形式。";
+"batchimExplanation" = "有不用作声母的双 Batchims，但很少使用，所以不用担心！";
+"vowelExplanation2" = "'ㅡ'总是在辅音下面，\n而'ㅣ'在右边。";
+"vowelExplanation3" = "一个•被添加到基本元音中。";
+"vowelExplanation4" = "两个•被添加到基本元音中。";
+"vowelExplanation5" = "'•'和'ㅣ'被添加到基本元音中。";
+"vowelExplanation6" = "两个元音合二为一！\n按顺序快速阅读。";
+"vowelDone" = "你已经学会了韩文的元音！";
+"consonantDone" = "你已经学会了韩文的辅音！";
+"batchimDone" = "你已经学会了韩文的Batchim！";
+"learnConsonant" = "学习辅音";
+"learnBatchim" = "学习Batchim";
+"goToQuiz" = "去测验";
+"correct" = "正确的！";
+"tryAgain" = "再试一次...";
+"youHaveFinished" = "到目前为止，您已经完成了";
+"questionsSoFar" = "个问题";
+"lv1" = "lv 1。元音";
+"lv3" = "lv 3。Batchim";
+"lv2" = "lv 2。辅音";
+"check" = "确认";
+"velarSound" = "口盖音";
+"lingualSound" = "舌音";
+"labialSound" = "唇音";
+"dentalSound" = "齒音";
+"gutturalSound" = "喉音";
+"velarSoundExplanation" = "舌头接触软腭的形状";
+"lingualSoundExplanation" = "舌尖接触上牙龈的形状";
+"labialSoundExplanation" = "嘴唇的形状";
+"dentalSoundExplanation" = "牙齿的形状";
+"gutturalSoundExplanation" = "喉咙的形状";
+"combine" = "结合你自己的韩文，听听它的声音。";

--- a/HangulTop/Screen/Base.lproj/Consonant.storyboard
+++ b/HangulTop/Screen/Base.lproj/Consonant.storyboard
@@ -1025,28 +1025,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rEx-eD-HBx">
-                                <rect key="frame" x="127.66666666666669" y="663" width="120" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="lYo-Yb-gSR"/>
-                                    <constraint firstAttribute="width" secondItem="rEx-eD-HBx" secondAttribute="height" multiplier="4:1" id="oLO-a8-fKC"/>
-                                </constraints>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal">
-                                    <attributedString key="attributedTitle">
-                                        <fragment content="Back to Main">
-                                            <attributes>
-                                                <color key="NSColor" systemColor="labelColor"/>
-                                                <font key="NSFont" metaFont="system" size="17"/>
-                                                <integer key="NSUnderline" value="1"/>
-                                            </attributes>
-                                        </fragment>
-                                    </attributedString>
-                                </state>
-                                <connections>
-                                    <action selector="goToMenu:" destination="O5O-Nr-ODP" eventType="touchUpInside" id="0Cx-Jk-tpv"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EDV-e4-OmA">
                                 <rect key="frame" x="62.666666666666657" y="573" width="249.99999999999997" height="60"/>
                                 <constraints>
@@ -1076,6 +1054,21 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="animationName" value="finish"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rEx-eD-HBx">
+                                <rect key="frame" x="116.66666666666669" y="663" width="142" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="lYo-Yb-gSR"/>
+                                    <constraint firstAttribute="width" secondItem="rEx-eD-HBx" secondAttribute="height" multiplier="4:1" constant="22" id="oLO-a8-fKC"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="Back to Main">
+                                    <color key="titleColor" systemColor="labelColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="goToMain:" destination="O5O-Nr-ODP" eventType="touchUpInside" id="bLI-og-Z6M"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="jAb-9o-ZQx"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -1094,6 +1087,7 @@
                     </view>
                     <connections>
                         <outlet property="animationView" destination="pUv-rN-L8j" id="xHJ-oR-uCO"/>
+                        <outlet property="goToMain" destination="rEx-eD-HBx" id="ehQ-7w-SP0"/>
                         <outlet property="goToStudy" destination="EDV-e4-OmA" id="GqN-ZQ-GJu"/>
                         <outlet property="message" destination="VEV-vw-fiw" id="Wd0-DW-2KN"/>
                     </connections>

--- a/HangulTop/Screen/Base.lproj/Consonant.storyboard
+++ b/HangulTop/Screen/Base.lproj/Consonant.storyboard
@@ -25,13 +25,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6zW-a1-xOB">
-                                <rect key="frame" x="30" y="595" width="315" height="75.666666666666629"/>
+                                <rect key="frame" x="30" y="606.66666666666663" width="315" height="75.333333333333371"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7jG-bs-4jv">
-                                        <rect key="frame" x="10" y="0.0" width="295" height="75.666666666666671"/>
+                                        <rect key="frame" x="10" y="0.0" width="295" height="75.333333333333329"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="VpT-Kg-2A1">
-                                                <rect key="frame" x="0.0" y="-2.3333333333333357" width="20" height="81"/>
+                                                <rect key="frame" x="0.0" y="-2.3333333333333357" width="20" height="80.666666666666657"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="20" id="ySK-h5-ZkA"/>
@@ -39,7 +39,7 @@
                                                 <imageReference key="image" image="smiley.fill" catalog="system" symbolScale="large"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="모음은 단독으로 쓰이지 않기 때문에, 여기선 첫번째로 올 때 음가가 없는 자음’ㅇ'을 모음 앞의 공백을 표시하는 기호로 쓸 것입니다." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KAI-Vr-Ee5">
-                                                <rect key="frame" x="40" y="0.0" width="255" height="75.666666666666671"/>
+                                                <rect key="frame" x="40" y="0.0" width="255" height="75.333333333333329"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -64,7 +64,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pae-bh-4q7">
-                                <rect key="frame" x="74.666666666666686" y="690.66666666666663" width="226" height="60"/>
+                                <rect key="frame" x="74.666666666666686" y="702" width="226" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="VHe-lC-UNJ"/>
                                     <constraint firstAttribute="width" secondItem="Pae-bh-4q7" secondAttribute="height" multiplier="113:30" id="puX-3W-Nit"/>
@@ -86,7 +86,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Vd-st-bSF" customClass="AnimationView" customModule="Lottie">
-                                <rect key="frame" x="75" y="89" width="225" height="225"/>
+                                <rect key="frame" x="75" y="88.999999999999986" width="225" height="236.66666666666663"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="1Vd-st-bSF" secondAttribute="height" multiplier="1:1" id="Eid-wa-93m"/>
@@ -96,7 +96,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uPd-wb-DiX" customClass="AnimationView" customModule="Lottie">
-                                <rect key="frame" x="75" y="89" width="225" height="225"/>
+                                <rect key="frame" x="75" y="88.999999999999986" width="225" height="236.66666666666663"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="uPd-wb-DiX" secondAttribute="height" multiplier="1:1" id="ISi-Bo-frS"/>
@@ -106,7 +106,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PK7-HP-lw7" customClass="AnimationView" customModule="Lottie">
-                                <rect key="frame" x="75" y="89" width="225" height="225"/>
+                                <rect key="frame" x="75" y="88.999999999999986" width="225" height="236.66666666666663"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="PK7-HP-lw7" secondAttribute="height" multiplier="1:1" id="j7V-al-9bQ"/>
@@ -116,7 +116,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DyM-6y-Sdz">
-                                <rect key="frame" x="30" y="324" width="315" height="251"/>
+                                <rect key="frame" x="30" y="335.66666666666669" width="315" height="251.00000000000006"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="251" id="Doo-VY-dHY"/>
                                 </constraints>

--- a/HangulTop/Screen/Base.lproj/HangulView.storyboard
+++ b/HangulTop/Screen/Base.lproj/HangulView.storyboard
@@ -10,7 +10,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--hangul-->
+        <!--Hangul-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
                 <viewController storyboardIdentifier="HangulView" id="Y6W-OH-hqX" customClass="HangulViewController" customModule="HangulTop" customModuleProvider="target" sceneMemberID="viewController">
@@ -479,7 +479,7 @@
                             <constraint firstItem="35F-vX-Tx4" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="40" id="wvc-yP-qW7"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="hangul" id="HrE-sl-dhQ"/>
+                    <navigationItem key="navigationItem" title="Hangul" id="HrE-sl-dhQ"/>
                     <connections>
                         <outlet property="captionView" destination="p57-m2-DvJ" id="WCB-2X-dV7"/>
                         <outlet property="mainLetter" destination="8Pm-ag-fMg" id="0Xw-11-Wsb"/>

--- a/HangulTop/Screen/es.lproj/HangulView.strings
+++ b/HangulTop/Screen/es.lproj/HangulView.strings
@@ -27,7 +27,7 @@
 "CtY-Vk-nJb.normalTitle" = "사";
 
 /* Class = "UINavigationItem"; title = "hangul"; ObjectID = "HrE-sl-dhQ"; */
-"HrE-sl-dhQ.title" = "hangul";
+"HrE-sl-dhQ.title" = "Hangul";
 
 /* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "IJ2-cE-soa"; */
 "IJ2-cE-soa.normalTitle" = "ㄱ";

--- a/HangulTop/Screen/id.lproj/HangulView.strings
+++ b/HangulTop/Screen/id.lproj/HangulView.strings
@@ -27,7 +27,7 @@
 "CtY-Vk-nJb.normalTitle" = "사";
 
 /* Class = "UINavigationItem"; title = "hangul"; ObjectID = "HrE-sl-dhQ"; */
-"HrE-sl-dhQ.title" = "hangul";
+"HrE-sl-dhQ.title" = "Hangul";
 
 /* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "IJ2-cE-soa"; */
 "IJ2-cE-soa.normalTitle" = "ㄱ";

--- a/HangulTop/Screen/ja.lproj/Consonant.strings
+++ b/HangulTop/Screen/ja.lproj/Consonant.strings
@@ -1,0 +1,82 @@
+
+/* Class = "UIButton"; configuration.title = "Next"; ObjectID = "6t8-Ai-TNn"; */
+"6t8-Ai-TNn.configuration.title" = "次";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "6t8-Ai-TNn"; */
+"6t8-Ai-TNn.normalTitle" = "次";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "7cz-qf-bsb"; */
+"7cz-qf-bsb.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "Cus-J0-RL8"; */
+"Cus-J0-RL8.normalTitle" = "Button";
+
+/* Class = "UILabel"; text = "자음은 총 19개로, 기본자음 14개와 \n복합자음(ㄲ,ㄸ,ㅃ,ㅆ,ㅉ) 5개로 구성되어 있다."; ObjectID = "DyM-6y-Sdz"; */
+"DyM-6y-Sdz.text" = "자음은 총 19개로, 기본자음 14개와 \n복합자음(ㄲ,ㄸ,ㅃ,ㅆ,ㅉ) 5개로 구성되어 있다.";
+
+/* Class = "UIButton"; configuration.title = "Go to Consonant"; ObjectID = "EDV-e4-OmA"; */
+"EDV-e4-OmA.configuration.title" = "子音学習";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "EDV-e4-OmA"; */
+"EDV-e4-OmA.normalTitle" = "子音学習";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "GOZ-O0-pXg"; */
+"GOZ-O0-pXg.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "HXp-N8-RyY"; */
+"HXp-N8-RyY.normalTitle" = "Button";
+
+/* Class = "UILabel"; text = "모음은 단독으로 쓰이지 않기 때문에, 여기선 첫번째로 올 때 음가가 없는 자음’ㅇ'을 모음 앞의 공백을 표시하는 기호로 쓸 것입니다."; ObjectID = "KAI-Vr-Ee5"; */
+"KAI-Vr-Ee5.text" = "母音は単独では使用されません。ここで「ㅇ」は、各母音の前の空白を表します。";
+
+/* Class = "UILabel"; text = "가"; ObjectID = "MdL-uT-XHm"; */
+"MdL-uT-XHm.text" = "가";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "MeM-06-4Vz"; */
+"MeM-06-4Vz.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "OfJ-8R-Y9i"; */
+"OfJ-8R-Y9i.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; configuration.title = "  Start"; ObjectID = "Pae-bh-4q7"; */
+"Pae-bh-4q7.configuration.title" = "  スタート";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "Pae-bh-4q7"; */
+"Pae-bh-4q7.normalTitle" = "スタート";
+
+/* Class = "UILabel"; text = "You have learned the vowels of Hangul!"; ObjectID = "VEV-vw-fiw"; */
+"VEV-vw-fiw.text" = "ハングルの母音を\n覚えたんですね！";
+
+/* Class = "UILabel"; text = "ㅡ always goes below the consonant, whereas ㅣ goes to the right."; ObjectID = "Yo3-nM-VrJ"; */
+"Yo3-nM-VrJ.text" = "「ㅡ」 は常に子音の下に移動しますが、\n「ㅣ」 は右に移動します。";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "Yxa-bS-iaj"; */
+"Yxa-bS-iaj.normalTitle" = "Button";
+
+/* Class = "UIButton"; normalTitle = " "; ObjectID = "caH-XU-l8j"; */
+"caH-XU-l8j.normalTitle" = " ";
+
+/* Class = "UIButton"; configuration.title = "Prev"; ObjectID = "jvd-Sm-T7F"; */
+"jvd-Sm-T7F.configuration.title" = "前";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "jvd-Sm-T7F"; */
+"jvd-Sm-T7F.normalTitle" = "前";
+
+/* Class = "UIButton"; configuration.title = "ㅡ"; ObjectID = "m65-9W-0AK"; */
+"m65-9W-0AK.configuration.title" = "ㅡ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "m65-9W-0AK"; */
+"m65-9W-0AK.normalTitle" = "Button";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "pRA-6O-qyA"; */
+"pRA-6O-qyA.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "qrJ-4H-d05"; */
+"qrJ-4H-d05.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "rDk-Rj-lDF"; */
+"rDk-Rj-lDF.normalTitle" = "ㄱ";
+
+// BACK TO MAIN
+"rEx-eD-HBx.configuration.title" = "メインに戻る";
+"rEx-eD-HBx.normalTitle" = "メインに戻る";

--- a/HangulTop/Screen/ja.lproj/HangulView.strings
+++ b/HangulTop/Screen/ja.lproj/HangulView.strings
@@ -3,7 +3,7 @@
 "5tu-eU-reG.normalTitle" = "아";
 
 /* Class = "UIButton"; normalTitle = "Button"; ObjectID = "68f-SU-Ar2"; */
-"68f-SU-Ar2.normalTitle" = "Bouton";
+"68f-SU-Ar2.normalTitle" = "Button";
 
 /* Class = "UIButton"; normalTitle = "하"; ObjectID = "7tz-vP-j2x"; */
 "7tz-vP-j2x.normalTitle" = "하";
@@ -27,7 +27,7 @@
 "CtY-Vk-nJb.normalTitle" = "사";
 
 /* Class = "UINavigationItem"; title = "hangul"; ObjectID = "HrE-sl-dhQ"; */
-"HrE-sl-dhQ.title" = "Hangul";
+"HrE-sl-dhQ.title" = "ハングル";
 
 /* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "IJ2-cE-soa"; */
 "IJ2-cE-soa.normalTitle" = "ㄱ";
@@ -45,13 +45,13 @@
 "ONE-0b-Fcb.normalTitle" = "ㅂ";
 
 /* Class = "UISegmentedControl"; QCV-BQ-kcd.segmentTitles[0] = "Consonant"; ObjectID = "QCV-BQ-kcd"; */
-"QCV-BQ-kcd.segmentTitles[0]" = "Consonne";
+"QCV-BQ-kcd.segmentTitles[0]" = "子音";
 
 /* Class = "UISegmentedControl"; QCV-BQ-kcd.segmentTitles[1] = "Vowel"; ObjectID = "QCV-BQ-kcd"; */
-"QCV-BQ-kcd.segmentTitles[1]" = "Voyelle";
+"QCV-BQ-kcd.segmentTitles[1]" = "母音";
 
 /* Class = "UISegmentedControl"; QCV-BQ-kcd.segmentTitles[2] = "Batchim"; ObjectID = "QCV-BQ-kcd"; */
-"QCV-BQ-kcd.segmentTitles[2]" = "Batchim";
+"QCV-BQ-kcd.segmentTitles[2]" = "バッチム";
 
 /* Class = "UIButton"; normalTitle = "마"; ObjectID = "U1p-li-0T7"; */
 "U1p-li-0T7.normalTitle" = "마";
@@ -75,7 +75,7 @@
 "eQY-jK-T1J.normalTitle" = "라";
 
 /* Class = "UILabel"; text = "Combine your own Hangul and listen  to how it sounds like."; ObjectID = "jqz-8B-yYt"; */
-"jqz-8B-yYt.text" = "Combinez votre propre Hangul et écoutez  comment cela ressemble.";
+"jqz-8B-yYt.text" = "独自のハングルを組み合わせて、それが\nどのように聞こえるかを聞いてください。";
 
 /* Class = "UIButton"; normalTitle = "가"; ObjectID = "k1H-nI-Net"; */
 "k1H-nI-Net.normalTitle" = "가";

--- a/HangulTop/Screen/ja.lproj/Main.strings
+++ b/HangulTop/Screen/ja.lproj/Main.strings
@@ -1,0 +1,42 @@
+
+/* Class = "UILabel"; text = "Practice"; ObjectID = "GAo-4h-kBf"; */
+"GAo-4h-kBf.text" = "練習";
+
+/* Class = "UIButton"; configuration.title = "Hangul"; ObjectID = "JtG-Tx-ie9"; */
+"JtG-Tx-ie9.configuration.title" = "ハングル";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "JtG-Tx-ie9"; */
+"JtG-Tx-ie9.normalTitle" = "ハングル";
+
+/* Class = "UIButton"; configuration.title = "Quiz"; ObjectID = "LOH-WO-KYp"; */
+"LOH-WO-KYp.configuration.title" = "クイズ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "LOH-WO-KYp"; */
+"LOH-WO-KYp.normalTitle" = "クイズ";
+
+/* Class = "UILabel"; text = "한글킹"; ObjectID = "PBI-2k-mQS"; */
+"PBI-2k-mQS.text" = "한글킹";
+
+/* Class = "UILabel"; text = "Learn"; ObjectID = "PPg-u7-SlT"; */
+"PPg-u7-SlT.text" = "学習";
+
+/* Class = "UIButton"; configuration.title = "Vowel"; ObjectID = "V3Y-WB-fQo"; */
+"V3Y-WB-fQo.configuration.title" = "母音";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "V3Y-WB-fQo"; */
+"V3Y-WB-fQo.normalTitle" = "母音";
+
+/* Class = "UIButton"; configuration.title = "Batchim"; ObjectID = "fHQ-dK-aUX"; */
+"fHQ-dK-aUX.configuration.title" = "バッチム";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "fHQ-dK-aUX"; */
+"fHQ-dK-aUX.normalTitle" = "バッチム";
+
+/* Class = "UIButton"; configuration.title = "Consonant"; ObjectID = "oUU-R5-0ue"; */
+"oUU-R5-0ue.configuration.title" = "子音";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "oUU-R5-0ue"; */
+"oUU-R5-0ue.normalTitle" = "子音";
+
+/* Class = "UIBarButtonItem"; title = "Home"; ObjectID = "tIG-nm-Ebk"; */
+"tIG-nm-Ebk.title" = "Home";

--- a/HangulTop/Screen/ja.lproj/Quiz.strings
+++ b/HangulTop/Screen/ja.lproj/Quiz.strings
@@ -1,0 +1,78 @@
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "8al-8R-cWf"; */
+"8al-8R-cWf.normalTitle" = "ㅏ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "8dy-Ur-jqw"; */
+"8dy-Ur-jqw.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "CeC-7I-pKf"; */
+"CeC-7I-pKf.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "DnB-7k-GW9"; */
+"DnB-7k-GW9.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "GHK-X9-xSJ"; */
+"GHK-X9-xSJ.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "Check"; ObjectID = "IHm-1a-0Wj"; */
+"IHm-1a-0Wj.normalTitle" = "確認";
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "JxA-1v-Vw3"; */
+"JxA-1v-Vw3.normalTitle" = "ㅏ";
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "M39-aF-jJF"; */
+"M39-aF-jJF.normalTitle" = "ㅏ";
+
+/* Class = "UINavigationItem"; title = "Quiz"; ObjectID = "Oik-0W-ppF"; */
+"Oik-0W-ppF.title" = "クイズ";
+
+/* Class = "UILabel"; text = "_"; ObjectID = "QiO-j9-abg"; */
+"QiO-j9-abg.text" = "_";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "SqX-e1-Kjg"; */
+"SqX-e1-Kjg.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "YPD-4U-nDO"; */
+"YPD-4U-nDO.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "alj-4K-Geb"; */
+"alj-4K-Geb.normalTitle" = "Button";
+
+/* Class = "UILabel"; text = "1 / 10"; ObjectID = "dvx-qa-5Uz"; */
+"dvx-qa-5Uz.text" = "1 / 10";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "eI0-bZ-ICS"; */
+"eI0-bZ-ICS.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; configuration.title = "Finish"; ObjectID = "g9I-Kr-OD8"; */
+"g9I-Kr-OD8.configuration.title" = "完了";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "g9I-Kr-OD8"; */
+"g9I-Kr-OD8.normalTitle" = "完了";
+
+/* Class = "UILabel"; text = "Press the buttons to listen to the sound."; ObjectID = "ner-5t-LMf"; */
+"ner-5t-LMf.text" = "ボタンを押して音を闻きます。";
+
+/* Class = "UILabel"; text = "lv 1. Vowel"; ObjectID = "np5-bI-rRI"; */
+"np5-bI-rRI.text" = "lv 1。母音";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "p1d-Sc-eXC"; */
+"p1d-Sc-eXC.normalTitle" = "ㅜ";
+
+/* Class = "UILabel"; text = "Latest quiz"; ObjectID = "s2D-fA-lrA"; */
+"s2D-fA-lrA.text" = "最新のクイズ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "sYb-VE-aI4"; */
+"sYb-VE-aI4.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "smC-Ef-mcN"; */
+"smC-Ef-mcN.normalTitle" = "ㅏ";
+
+/* Class = "UILabel"; text = "Tap the bird to listen to the sound.\nChoose the letter that represents the sound."; ObjectID = "uhU-gJ-rA3"; */
+"uhU-gJ-rA3.text" = "鳥をタップして音を聞きます。\n音を表す文字を選択します。";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "vri-So-7b5"; */
+"vri-So-7b5.normalTitle" = "ㅜ";
+
+/* Class = "UILabel"; text = "congratulations!"; ObjectID = "wW5-bp-yXJ"; */
+"wW5-bp-yXJ.text" = "おめでとう！";

--- a/HangulTop/Screen/ms.lproj/HangulView.strings
+++ b/HangulTop/Screen/ms.lproj/HangulView.strings
@@ -27,7 +27,7 @@
 "CtY-Vk-nJb.normalTitle" = "사";
 
 /* Class = "UINavigationItem"; title = "hangul"; ObjectID = "HrE-sl-dhQ"; */
-"HrE-sl-dhQ.title" = "hangul";
+"HrE-sl-dhQ.title" = "Hangul";
 
 /* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "IJ2-cE-soa"; */
 "IJ2-cE-soa.normalTitle" = "ㄱ";

--- a/HangulTop/Screen/zh-Hans.lproj/Consonant.strings
+++ b/HangulTop/Screen/zh-Hans.lproj/Consonant.strings
@@ -1,0 +1,81 @@
+
+/* Class = "UIButton"; configuration.title = "Next"; ObjectID = "6t8-Ai-TNn"; */
+"6t8-Ai-TNn.configuration.title" = "下一页";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "6t8-Ai-TNn"; */
+"6t8-Ai-TNn.normalTitle" = "下一页";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "7cz-qf-bsb"; */
+"7cz-qf-bsb.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "Cus-J0-RL8"; */
+"Cus-J0-RL8.normalTitle" = "Button";
+
+/* Class = "UILabel"; text = "자음은 총 19개로, 기본자음 14개와 \n복합자음(ㄲ,ㄸ,ㅃ,ㅆ,ㅉ) 5개로 구성되어 있다."; ObjectID = "DyM-6y-Sdz"; */
+"DyM-6y-Sdz.text" = "자음은 총 19개로, 기본자음 14개와 \n복합자음(ㄲ,ㄸ,ㅃ,ㅆ,ㅉ) 5개로 구성되어 있다.";
+
+/* Class = "UIButton"; configuration.title = "Go to Consonant"; ObjectID = "EDV-e4-OmA"; */
+"EDV-e4-OmA.configuration.title" = "学习辅音";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "EDV-e4-OmA"; */
+"EDV-e4-OmA.normalTitle" = "学习辅音";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "GOZ-O0-pXg"; */
+"GOZ-O0-pXg.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "HXp-N8-RyY"; */
+"HXp-N8-RyY.normalTitle" = "Button";
+
+/* Class = "UILabel"; text = "모음은 단독으로 쓰이지 않기 때문에, 여기선 첫번째로 올 때 음가가 없는 자음’ㅇ'을 모음 앞의 공백을 표시하는 기호로 쓸 것입니다."; ObjectID = "KAI-Vr-Ee5"; */
+"KAI-Vr-Ee5.text" = "元音不单独使用。这里的'ㅇ'表示每个元音前面的语音空白。";
+
+/* Class = "UILabel"; text = "가"; ObjectID = "MdL-uT-XHm"; */
+"MdL-uT-XHm.text" = "가";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "MeM-06-4Vz"; */
+"MeM-06-4Vz.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "OfJ-8R-Y9i"; */
+"OfJ-8R-Y9i.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; configuration.title = "  Start"; ObjectID = "Pae-bh-4q7"; */
+"Pae-bh-4q7.configuration.title" = "  开始";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "Pae-bh-4q7"; */
+"Pae-bh-4q7.normalTitle" = "开始";
+
+/* Class = "UILabel"; text = "You have learned the vowels of Hangul!"; ObjectID = "VEV-vw-fiw"; */
+"VEV-vw-fiw.text" = "你已经学会了韩文的元音！";
+
+/* Class = "UILabel"; text = "ㅡ always goes below the consonant, whereas ㅣ goes to the right."; ObjectID = "Yo3-nM-VrJ"; */
+"Yo3-nM-VrJ.text" = "'ㅡ'总是在辅音下面，\n而'ㅣ'在右边。";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "Yxa-bS-iaj"; */
+"Yxa-bS-iaj.normalTitle" = "Button";
+
+/* Class = "UIButton"; normalTitle = " "; ObjectID = "caH-XU-l8j"; */
+"caH-XU-l8j.normalTitle" = " ";
+
+/* Class = "UIButton"; configuration.title = "Prev"; ObjectID = "jvd-Sm-T7F"; */
+"jvd-Sm-T7F.configuration.title" = "上一页数";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "jvd-Sm-T7F"; */
+"jvd-Sm-T7F.normalTitle" = "上一页数";
+
+/* Class = "UIButton"; configuration.title = "ㅡ"; ObjectID = "m65-9W-0AK"; */
+"m65-9W-0AK.configuration.title" = "ㅡ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "m65-9W-0AK"; */
+"m65-9W-0AK.normalTitle" = "Button";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "pRA-6O-qyA"; */
+"pRA-6O-qyA.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "qrJ-4H-d05"; */
+"qrJ-4H-d05.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "rDk-Rj-lDF"; */
+"rDk-Rj-lDF.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "Back to Main"; ObjectID = "rEx-eD-HBx"; */
+"rEx-eD-HBx.normalTitle" = "回到主要";

--- a/HangulTop/Screen/zh-Hans.lproj/HangulView.strings
+++ b/HangulTop/Screen/zh-Hans.lproj/HangulView.strings
@@ -1,0 +1,105 @@
+
+/* Class = "UIButton"; normalTitle = "아"; ObjectID = "5tu-eU-reG"; */
+"5tu-eU-reG.normalTitle" = "아";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "68f-SU-Ar2"; */
+"68f-SU-Ar2.normalTitle" = "Button";
+
+/* Class = "UIButton"; normalTitle = "하"; ObjectID = "7tz-vP-j2x"; */
+"7tz-vP-j2x.normalTitle" = "하";
+
+/* Class = "UILabel"; text = "가"; ObjectID = "8Pm-ag-fMg"; */
+"8Pm-ag-fMg.text" = "가";
+
+/* Class = "UIButton"; normalTitle = "나"; ObjectID = "9oC-uv-CM4"; */
+"9oC-uv-CM4.normalTitle" = "나";
+
+/* Class = "UIButton"; normalTitle = "차"; ObjectID = "9z1-PW-MkM"; */
+"9z1-PW-MkM.normalTitle" = "차";
+
+/* Class = "UIButton"; normalTitle = "다"; ObjectID = "AXt-vy-7sF"; */
+"AXt-vy-7sF.normalTitle" = "다";
+
+/* Class = "UIButton"; normalTitle = "ㄷ"; ObjectID = "Bge-nD-OPY"; */
+"Bge-nD-OPY.normalTitle" = "ㄷ";
+
+/* Class = "UIButton"; normalTitle = "사"; ObjectID = "CtY-Vk-nJb"; */
+"CtY-Vk-nJb.normalTitle" = "사";
+
+/* Class = "UINavigationItem"; title = "Hangul"; ObjectID = "HrE-sl-dhQ"; */
+"HrE-sl-dhQ.title" = "韩文";
+
+/* Class = "UIButton"; normalTitle = "ㄱ"; ObjectID = "IJ2-cE-soa"; */
+"IJ2-cE-soa.normalTitle" = "ㄱ";
+
+/* Class = "UIButton"; normalTitle = "타"; ObjectID = "ISi-VY-Fr1"; */
+"ISi-VY-Fr1.normalTitle" = "타";
+
+/* Class = "UIButton"; normalTitle = "ㅁ"; ObjectID = "LUI-cT-Tux"; */
+"LUI-cT-Tux.normalTitle" = "ㅁ";
+
+/* Class = "UIButton"; normalTitle = "ㅅ"; ObjectID = "OGY-gm-gys"; */
+"OGY-gm-gys.normalTitle" = "ㅅ";
+
+/* Class = "UIButton"; normalTitle = "ㅂ"; ObjectID = "ONE-0b-Fcb"; */
+"ONE-0b-Fcb.normalTitle" = "ㅂ";
+
+/* Class = "UISegmentedControl"; QCV-BQ-kcd.segmentTitles[0] = "Consonant"; ObjectID = "QCV-BQ-kcd"; */
+"QCV-BQ-kcd.segmentTitles[0]" = "辅音";
+
+/* Class = "UISegmentedControl"; QCV-BQ-kcd.segmentTitles[1] = "Vowel"; ObjectID = "QCV-BQ-kcd"; */
+"QCV-BQ-kcd.segmentTitles[1]" = "元音";
+
+/* Class = "UISegmentedControl"; QCV-BQ-kcd.segmentTitles[2] = "Batchim"; ObjectID = "QCV-BQ-kcd"; */
+"QCV-BQ-kcd.segmentTitles[2]" = "Batchim";
+
+/* Class = "UIButton"; normalTitle = "마"; ObjectID = "U1p-li-0T7"; */
+"U1p-li-0T7.normalTitle" = "마";
+
+/* Class = "UIButton"; normalTitle = "ㅍ"; ObjectID = "Ued-5w-cxV"; */
+"Ued-5w-cxV.normalTitle" = "ㅍ";
+
+/* Class = "UIButton"; normalTitle = "ㅊ"; ObjectID = "XHh-l1-tHq"; */
+"XHh-l1-tHq.normalTitle" = "ㅊ";
+
+/* Class = "UIButton"; normalTitle = "ㅇ"; ObjectID = "XJe-bB-YU6"; */
+"XJe-bB-YU6.normalTitle" = "ㅇ";
+
+/* Class = "UIButton"; normalTitle = "ㅈ"; ObjectID = "YTh-Ls-Hat"; */
+"YTh-Ls-Hat.normalTitle" = "ㅈ";
+
+/* Class = "UIButton"; normalTitle = "카"; ObjectID = "cWe-ZU-RrG"; */
+"cWe-ZU-RrG.normalTitle" = "카";
+
+/* Class = "UIButton"; normalTitle = "라"; ObjectID = "eQY-jK-T1J"; */
+"eQY-jK-T1J.normalTitle" = "라";
+
+/* Class = "UILabel"; text = "Combine your own Hangul and listen  to how it sounds like."; ObjectID = "jqz-8B-yYt"; */
+"jqz-8B-yYt.text" = "结合你自己的韩文，听听它的声音。";
+
+/* Class = "UIButton"; normalTitle = "가"; ObjectID = "k1H-nI-Net"; */
+"k1H-nI-Net.normalTitle" = "가";
+
+/* Class = "UIButton"; normalTitle = "ㄴ"; ObjectID = "kE1-Hh-keL"; */
+"kE1-Hh-keL.normalTitle" = "ㄴ";
+
+/* Class = "UIButton"; normalTitle = "ㅌ"; ObjectID = "kSu-yN-4Cu"; */
+"kSu-yN-4Cu.normalTitle" = "ㅌ";
+
+/* Class = "UIButton"; normalTitle = "ㅎ"; ObjectID = "kgj-Mz-Mdu"; */
+"kgj-Mz-Mdu.normalTitle" = "ㅎ";
+
+/* Class = "UIButton"; normalTitle = "바"; ObjectID = "rJQ-aa-D50"; */
+"rJQ-aa-D50.normalTitle" = "바";
+
+/* Class = "UIButton"; normalTitle = "ㄹ"; ObjectID = "reY-cd-0lF"; */
+"reY-cd-0lF.normalTitle" = "ㄹ";
+
+/* Class = "UIButton"; normalTitle = "파"; ObjectID = "tjz-aN-fvX"; */
+"tjz-aN-fvX.normalTitle" = "파";
+
+/* Class = "UIButton"; normalTitle = "ㅋ"; ObjectID = "tuC-tJ-wRg"; */
+"tuC-tJ-wRg.normalTitle" = "ㅋ";
+
+/* Class = "UIButton"; normalTitle = "자"; ObjectID = "yIs-WW-9eJ"; */
+"yIs-WW-9eJ.normalTitle" = "자";

--- a/HangulTop/Screen/zh-Hans.lproj/Main.strings
+++ b/HangulTop/Screen/zh-Hans.lproj/Main.strings
@@ -1,0 +1,42 @@
+
+/* Class = "UILabel"; text = "Practice"; ObjectID = "GAo-4h-kBf"; */
+"GAo-4h-kBf.text" = "练习";
+
+/* Class = "UIButton"; configuration.title = "Hangul"; ObjectID = "JtG-Tx-ie9"; */
+"JtG-Tx-ie9.configuration.title" = "韩文";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "JtG-Tx-ie9"; */
+"JtG-Tx-ie9.normalTitle" = "韩文";
+
+/* Class = "UIButton"; configuration.title = "Quiz"; ObjectID = "LOH-WO-KYp"; */
+"LOH-WO-KYp.configuration.title" = "测验";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "LOH-WO-KYp"; */
+"LOH-WO-KYp.normalTitle" = "测验";
+
+/* Class = "UILabel"; text = "한글킹"; ObjectID = "PBI-2k-mQS"; */
+"PBI-2k-mQS.text" = "한글킹";
+
+/* Class = "UILabel"; text = "Learn"; ObjectID = "PPg-u7-SlT"; */
+"PPg-u7-SlT.text" = "学";
+
+/* Class = "UIButton"; configuration.title = "Vowel"; ObjectID = "V3Y-WB-fQo"; */
+"V3Y-WB-fQo.configuration.title" = "元音";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "V3Y-WB-fQo"; */
+"V3Y-WB-fQo.normalTitle" = "元音";
+
+/* Class = "UIButton"; configuration.title = "Batchim"; ObjectID = "fHQ-dK-aUX"; */
+"fHQ-dK-aUX.configuration.title" = "Batchim";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "fHQ-dK-aUX"; */
+"fHQ-dK-aUX.normalTitle" = "Batchim";
+
+/* Class = "UIButton"; configuration.title = "Consonant"; ObjectID = "oUU-R5-0ue"; */
+"oUU-R5-0ue.configuration.title" = "辅音";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "oUU-R5-0ue"; */
+"oUU-R5-0ue.normalTitle" = "辅音";
+
+/* Class = "UIBarButtonItem"; title = "Home"; ObjectID = "tIG-nm-Ebk"; */
+"tIG-nm-Ebk.title" = "Home";

--- a/HangulTop/Screen/zh-Hans.lproj/Quiz.strings
+++ b/HangulTop/Screen/zh-Hans.lproj/Quiz.strings
@@ -1,0 +1,78 @@
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "8al-8R-cWf"; */
+"8al-8R-cWf.normalTitle" = "ㅏ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "8dy-Ur-jqw"; */
+"8dy-Ur-jqw.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "CeC-7I-pKf"; */
+"CeC-7I-pKf.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "DnB-7k-GW9"; */
+"DnB-7k-GW9.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "GHK-X9-xSJ"; */
+"GHK-X9-xSJ.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "Check"; ObjectID = "IHm-1a-0Wj"; */
+"IHm-1a-0Wj.normalTitle" = "确认";
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "JxA-1v-Vw3"; */
+"JxA-1v-Vw3.normalTitle" = "ㅏ";
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "M39-aF-jJF"; */
+"M39-aF-jJF.normalTitle" = "ㅏ";
+
+/* Class = "UINavigationItem"; title = "Quiz"; ObjectID = "Oik-0W-ppF"; */
+"Oik-0W-ppF.title" = "测验";
+
+/* Class = "UILabel"; text = "_"; ObjectID = "QiO-j9-abg"; */
+"QiO-j9-abg.text" = "_";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "SqX-e1-Kjg"; */
+"SqX-e1-Kjg.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "YPD-4U-nDO"; */
+"YPD-4U-nDO.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "alj-4K-Geb"; */
+"alj-4K-Geb.normalTitle" = "Button";
+
+/* Class = "UILabel"; text = "1 / 10"; ObjectID = "dvx-qa-5Uz"; */
+"dvx-qa-5Uz.text" = "1 / 10";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "eI0-bZ-ICS"; */
+"eI0-bZ-ICS.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; configuration.title = "Finish"; ObjectID = "g9I-Kr-OD8"; */
+"g9I-Kr-OD8.configuration.title" = "好了";
+
+/* Class = "UIButton"; normalTitle = "Button"; ObjectID = "g9I-Kr-OD8"; */
+"g9I-Kr-OD8.normalTitle" = "好了";
+
+/* Class = "UILabel"; text = "Press the buttons to listen to the sound."; ObjectID = "ner-5t-LMf"; */
+"ner-5t-LMf.text" = "按一下按钮听声音。";
+
+/* Class = "UILabel"; text = "lv 1. Vowel"; ObjectID = "np5-bI-rRI"; */
+"np5-bI-rRI.text" = "lv 1。元音";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "p1d-Sc-eXC"; */
+"p1d-Sc-eXC.normalTitle" = "ㅜ";
+
+/* Class = "UILabel"; text = "Latest quiz"; ObjectID = "s2D-fA-lrA"; */
+"s2D-fA-lrA.text" = "最新測驗";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "sYb-VE-aI4"; */
+"sYb-VE-aI4.normalTitle" = "ㅜ";
+
+/* Class = "UIButton"; normalTitle = "ㅏ"; ObjectID = "smC-Ef-mcN"; */
+"smC-Ef-mcN.normalTitle" = "ㅏ";
+
+/* Class = "UILabel"; text = "Tap the bird to listen to the sound.\nChoose the letter that represents the sound."; ObjectID = "uhU-gJ-rA3"; */
+"uhU-gJ-rA3.text" = "轻拍小鸟听声音。\n选择表示声音的字母。";
+
+/* Class = "UIButton"; normalTitle = "ㅜ"; ObjectID = "vri-So-7b5"; */
+"vri-So-7b5.normalTitle" = "ㅜ";
+
+/* Class = "UILabel"; text = "congratulations!"; ObjectID = "wW5-bp-yXJ"; */
+"wW5-bp-yXJ.text" = "祝贺你!";

--- a/HangulTop/ViewController/ConsonantEndViewController.swift
+++ b/HangulTop/ViewController/ConsonantEndViewController.swift
@@ -19,7 +19,9 @@ class ConsonantEndViewController: UIViewController {
     @IBOutlet weak var message: UILabel!
     @IBOutlet var animationView: AnimationView!
     @IBOutlet weak var goToStudy: UIButton!
-    @IBAction func goToMenu(_ sender: Any) {
+    @IBOutlet weak var goToMain: UIButton!
+    
+    @IBAction func goToMain(_ sender: Any) {
         //네비게이션 스택 중 원하는 지점으로 보내줌
         let controllers = self.navigationController?.viewControllers
         for vc in controllers! {
@@ -51,6 +53,7 @@ class ConsonantEndViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        addBottomBorder()
         message.text = messageArray[data ?? 0]
         if(data == 0){
             goToStudy.setTitle("learnConsonant".localized, for: .normal)
@@ -63,5 +66,14 @@ class ConsonantEndViewController: UIViewController {
         animationView.loopMode = .loop
         animationView.animationSpeed = 1
         animationView.play()
+    }
+    
+    func addBottomBorder() {
+        let thickness: CGFloat = 1.0
+        let bottomBorder = CALayer()
+        
+        bottomBorder.frame = CGRect(x:0, y: self.goToMain.frame.size.height - thickness, width: self.goToMain.frame.size.width, height:thickness)
+        bottomBorder.backgroundColor = UIColor.black.cgColor
+        goToMain.layer.addSublayer(bottomBorder)
     }
 }


### PR DESCRIPTION
## ❇️ Related-issue
- none

## ✳️ Description
- 일본어, 중국어(간체) localization 추가했습니다.
- Back to Main 버튼이 Localizable String에 포함되지 않는 이슈해결했습니다.
  : 스토리보드에서 attributed title 설정된 UIButton은 localization 지원하지 않는 것으로 확인 (https://developer.apple.com/forums/thread/661903)
  -> plain title로 수정 후 underline 따로 추가했습니다. 이후에 object ID로 직접 strings파일에 추가해주시면 됩니다.

<!-- 우측 project 설정해주세요. -->
