### PR TITLE
Fix: iOS 16버전 업데이트 이후 발음 사운드가 안남

### DIFF
--- a/HangulTop/ViewController/ConsonantViewController.swift
+++ b/HangulTop/ViewController/ConsonantViewController.swift
@@ -15,7 +15,7 @@ class ConsonantViewController: UIViewController, UICollectionViewDataSource,UICo
     var audioFile : URL!
     var audioRecorder : AVAudioRecorder!
     var isRecording = false
-    
+    let synthesizer = AVSpeechSynthesizer()
     //페이지 카운트 변수
     var pageNum = 0
     var indexCount: Int = 0
@@ -309,7 +309,7 @@ class ConsonantViewController: UIViewController, UICollectionViewDataSource,UICo
     
     // 발음 듣기
     func pronounce(_ letter: String) {
-        let synthesizer = AVSpeechSynthesizer()
+        
         let utterance = AVSpeechUtterance(string: letter)
         utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
         

--- a/HangulTop/ViewController/HangulViewController.swift
+++ b/HangulTop/ViewController/HangulViewController.swift
@@ -14,6 +14,7 @@ class HangulViewController: UIViewController{
     @IBOutlet var buttons: [UIButton]!
     @IBOutlet weak var mainLetter: UILabel!
     @IBOutlet weak var captionView: UIStackView!
+    let synthesizer = AVSpeechSynthesizer()
     var check: Int = 0
     var setLet = [[14, 20, 21, 22, 23, 24, 25, 26, 27],[14, 22, 23, 24, 25, 26, 27],[1]]
     var hangul: String = "앙"
@@ -98,7 +99,7 @@ class HangulViewController: UIViewController{
     }
     
     func pronounce(_ letter: String) {
-        let synthesizer = AVSpeechSynthesizer()
+        
         let utterance = AVSpeechUtterance(string: letter)
         utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
         

--- a/HangulTop/ViewController/QuizViewController.swift
+++ b/HangulTop/ViewController/QuizViewController.swift
@@ -25,6 +25,7 @@ class QuizViewController: UIViewController {
     @IBOutlet var buttons: [UIButton]!
     @IBOutlet weak var checkbutton: UIButton!
     @IBOutlet weak var quizCount: UILabel!
+    let synthesizer = AVSpeechSynthesizer()
     var count: Int = 0
     //MARK: - 버튼액션
     @IBAction func buttonAction(_ sender: UIButton) {
@@ -221,7 +222,7 @@ class QuizViewController: UIViewController {
         return resultStr
     }
     @IBAction func speakAnswer(_ sender: Any) {
-        let synthesizer = AVSpeechSynthesizer()
+        
         let utterance = AVSpeechUtterance(string: answers[pageNum])
         utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
     


### PR DESCRIPTION
## ❇️ Related-issue
- closes #109 

## Work Contents
- 사운드 출력 버튼을 눌렀을때 사운드가 출력되지 않음

## Trouble Point 
### 1.  TTS가 동작하지 않는다.

  - **Trouble Situation**
    -  iOS 16 업데이트 이후 AVSpeechSynthesizer가 함수 내에 local로 선언되어 있다면 함수가 종료될 때 할당이 즉시 해제되어 AVSpeechSynthesizer가 미쳐 speak를 끝까지 출력하지 못한다.

 - **Trouble Shooting**
    - AVSpeechSynthesizer를 함수 내에 local 변수로 선언하는 것이 아니라 instance로 선언하여 AVSpeechSynthesizer의 할당이 함수가 종료될 때 해제되지 않도록 하니 해결되었다. <a href="https://juhwa-coin.tistory.com/2">블로그</a>


```swift
let synthesizer = AVSpeechSynthesizer()

func pronounce(_ letter: String) {
        let utterance = AVSpeechUtterance(string: letter)
        utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")

        utterance.volume = 30
        utterance.rate = 0.4
        synthesizer.speak(utterance)
}
```

<!-- 우측 project 설정해주세요. -->
